### PR TITLE
rdbms 어뎁터에 세션 도입

### DIFF
--- a/internal/domain/entity/session.go
+++ b/internal/domain/entity/session.go
@@ -1,0 +1,35 @@
+package entity
+
+import (
+	"context"
+	"math/rand"
+	"time"
+)
+
+type Session struct {
+	// Unique identifier of each session
+	id  int
+	ctx context.Context
+
+	// conteains extra value of a session
+	// If loose typing becomes a problem,
+	// consider creating different structures for each usecase.
+	Info map[string]interface{}
+}
+
+func New(ctx context.Context) *Session {
+	rand.Seed(time.Now().Unix())
+
+	return &Session{
+		id:  rand.Int(),
+		ctx: ctx,
+	}
+}
+
+func (s *Session) GetId() int {
+	return s.id
+}
+
+func (s *Session) GetContext() context.Context {
+	return s.ctx
+}

--- a/internal/domain/entity/session/constructor.go
+++ b/internal/domain/entity/session/constructor.go
@@ -1,4 +1,4 @@
-package entity
+package session
 
 import (
 	"context"
@@ -24,12 +24,4 @@ func New(ctx context.Context) *Session {
 		id:  rand.Int(),
 		ctx: ctx,
 	}
-}
-
-func (s *Session) GetId() int {
-	return s.id
-}
-
-func (s *Session) GetContext() context.Context {
-	return s.ctx
 }

--- a/internal/domain/entity/session/methods.go
+++ b/internal/domain/entity/session/methods.go
@@ -1,0 +1,11 @@
+package session
+
+import "context"
+
+func (s *Session) GetId() int {
+	return s.id
+}
+
+func (s *Session) GetContext() context.Context {
+	return s.ctx
+}

--- a/internal/domain/service/registration/methods.go
+++ b/internal/domain/service/registration/methods.go
@@ -9,15 +9,19 @@ import (
 // This method automatically registers a product by accepting the product's code and location information.
 func (s RegistrationService) RegisterProduct(meta entity.ProductMeta) error {
 
-	s.metaRepo.Begin(context.Background())
-
-	err := s.metaRepo.StoreProductMeta(meta)
+	sess, err := s.metaRepo.CreateTxSession(context.TODO())
 
 	if err != nil {
-		s.metaRepo.Rollback()
+		return err
+	}
+
+	err = s.metaRepo.StoreProductMeta(sess, meta)
+
+	if err != nil {
+		s.metaRepo.Rollback(sess)
 		return err
 	} else {
-		s.metaRepo.Commit()
+		s.metaRepo.Commit(sess)
 		return nil
 	}
 }

--- a/internal/port/out/persistences.go
+++ b/internal/port/out/persistences.go
@@ -10,11 +10,11 @@ type MetadataRepositoryPort interface {
 	TransactorPort
 
 	// This method gets unique id of a product which can be hash, UUID and so on...
-	GetProductId(session entity.Session, code string) (string, error)
+	GetProductId(session *entity.Session, code string) (string, error)
 	// This method gets full metadata of a product
-	GetProductMeta(session entity.Session, id string) (entity.ProductMeta, error)
+	GetProductMeta(session *entity.Session, id string) (entity.ProductMeta, error)
 	// This method stores metadata to metadata repository which can be mysql, radius so on...
-	StoreProductMeta(session entity.Session, meta entity.ProductMeta) error
+	StoreProductMeta(session *entity.Session, meta entity.ProductMeta) error
 }
 
 type StatusPort interface {
@@ -28,11 +28,11 @@ type TradeRepositoryPort interface {
 	TransactorPort
 
 	// This method dumps trade data from trade data repository
-	DumpTradeRepo(session entity.Session) (entity.FileManager, error)
+	DumpTradeRepo() (entity.FileManager, error)
 	// This method dumps trade data created before a specific date
-	DumpTradeRepoBefore(session entity.Session, date time.Time) (entity.FileManager, error)
+	DumpTradeRepoBefore(date time.Time) (entity.FileManager, error)
 	// This method dumps trade data of specific product
-	DumpProduct(session entity.Session, id string) (entity.FileManager, error)
+	DumpProduct(id string) (entity.FileManager, error)
 	// This method dumps trade data of specific product created before time
-	DumpProductBefore(session entity.Session, id string, time time.Time) (entity.FileManager, error)
+	DumpProductBefore(id string, time time.Time) (entity.FileManager, error)
 }

--- a/internal/port/out/persistences.go
+++ b/internal/port/out/persistences.go
@@ -10,11 +10,11 @@ type MetadataRepositoryPort interface {
 	TransactorPort
 
 	// This method gets unique id of a product which can be hash, UUID and so on...
-	GetProductId(code string) (string, error)
+	GetProductId(session entity.Session, code string) (string, error)
 	// This method gets full metadata of a product
-	GetProductMeta(id string) (entity.ProductMeta, error)
+	GetProductMeta(session entity.Session, id string) (entity.ProductMeta, error)
 	// This method stores metadata to metadata repository which can be mysql, radius so on...
-	StoreProductMeta(meta entity.ProductMeta) error
+	StoreProductMeta(session entity.Session, meta entity.ProductMeta) error
 }
 
 type StatusPort interface {
@@ -28,11 +28,11 @@ type TradeRepositoryPort interface {
 	TransactorPort
 
 	// This method dumps trade data from trade data repository
-	DumpTradeRepo() (entity.FileManager, error)
+	DumpTradeRepo(session entity.Session) (entity.FileManager, error)
 	// This method dumps trade data created before a specific date
-	DumpTradeRepoBefore(date time.Time) (entity.FileManager, error)
+	DumpTradeRepoBefore(session entity.Session, date time.Time) (entity.FileManager, error)
 	// This method dumps trade data of specific product
-	DumpProduct(id string) (entity.FileManager, error)
+	DumpProduct(session entity.Session, id string) (entity.FileManager, error)
 	// This method dumps trade data of specific product created before time
-	DumpProductBefore(id string, time time.Time) (entity.FileManager, error)
+	DumpProductBefore(session entity.Session, id string, time time.Time) (entity.FileManager, error)
 }

--- a/internal/port/out/persistences.go
+++ b/internal/port/out/persistences.go
@@ -4,17 +4,18 @@ import (
 	"time"
 
 	"github.com/Goboolean/manager-cli/internal/domain/entity"
+	"github.com/Goboolean/manager-cli/internal/domain/entity/session"
 )
 
 type MetadataRepositoryPort interface {
 	TransactorPort
 
 	// This method gets unique id of a product which can be hash, UUID and so on...
-	GetProductId(session *entity.Session, code string) (string, error)
+	GetProductId(session *session.Session, code string) (string, error)
 	// This method gets full metadata of a product
-	GetProductMeta(session *entity.Session, id string) (entity.ProductMeta, error)
+	GetProductMeta(session *session.Session, id string) (entity.ProductMeta, error)
 	// This method stores metadata to metadata repository which can be mysql, radius so on...
-	StoreProductMeta(session *entity.Session, meta entity.ProductMeta) error
+	StoreProductMeta(session *session.Session, meta entity.ProductMeta) error
 }
 
 type StatusPort interface {

--- a/internal/port/out/transection.go
+++ b/internal/port/out/transection.go
@@ -1,10 +1,14 @@
 package out
 
-import "context"
+import (
+	"context"
+
+	"github.com/Goboolean/manager-cli/internal/domain/entity"
+)
 
 type TransactorPort interface {
-	Begin(ctx context.Context) error
-	Commit() error
-	Rollback() error
-	Context() context.Context
+	CreateNewSession(ctx context.Context) (entity.Session, error)
+	Begin(entity.Session) error
+	Commit(entity.Session) error
+	Rollback(entity.Session) error
 }

--- a/internal/port/out/transection.go
+++ b/internal/port/out/transection.go
@@ -3,12 +3,12 @@ package out
 import (
 	"context"
 
-	"github.com/Goboolean/manager-cli/internal/domain/entity"
+	"github.com/Goboolean/manager-cli/internal/domain/entity/session"
 )
 
 type TransactorPort interface {
-	CreateNewSession(ctx context.Context) *entity.Session
-	Begin(*entity.Session) error
-	Commit(*entity.Session) error
-	Rollback(*entity.Session) error
+	CreateNewSession(ctx context.Context) *session.Session
+	Begin(*session.Session) error
+	Commit(*session.Session) error
+	Rollback(*session.Session) error
 }

--- a/internal/port/out/transection.go
+++ b/internal/port/out/transection.go
@@ -7,8 +7,9 @@ import (
 )
 
 type TransactorPort interface {
-	CreateNewSession(ctx context.Context) *session.Session
-	Begin(*session.Session) error
-	Commit(*session.Session) error
-	Rollback(*session.Session) error
+	// Create new transaction and begin it.
+	// Returns a session object to manage each session of the transaction.
+	CreateTxSession(ctx context.Context) (*session.Session, error)
+	Commit(session *session.Session) error
+	Rollback(session *session.Session) error
 }

--- a/internal/port/out/transection.go
+++ b/internal/port/out/transection.go
@@ -7,8 +7,8 @@ import (
 )
 
 type TransactorPort interface {
-	CreateNewSession(ctx context.Context) (entity.Session, error)
-	Begin(entity.Session) error
-	Commit(entity.Session) error
-	Rollback(entity.Session) error
+	CreateNewSession(ctx context.Context) (*entity.Session, error)
+	Begin(*entity.Session) error
+	Commit(*entity.Session) error
+	Rollback(*entity.Session) error
 }

--- a/internal/port/out/transection.go
+++ b/internal/port/out/transection.go
@@ -7,7 +7,7 @@ import (
 )
 
 type TransactorPort interface {
-	CreateNewSession(ctx context.Context) (*entity.Session, error)
+	CreateNewSession(ctx context.Context) *entity.Session
 	Begin(*entity.Session) error
 	Commit(*entity.Session) error
 	Rollback(*entity.Session) error


### PR DESCRIPTION
# 주요 변경 사항
- 트랜젝터 인터페이스를 수정해 하나의 트랜젝션을 추상화한 session을 발급하고 rollback이나 commit시 session 정보를 받도록 했습니다.
- RDBMS어뎁터에서는 새로운 세션을 추가할 때 자동으로 트랜젝션 객체와 쿼리 객체를 sessionid와 매핑된 map자료구조에 저장하도록 했습니다.
- commit과 rollback시에는 각각 commit과 rollback동작을 수행하면서 저장된 transaction객체와 query객체를 삭제하도록 했습니다.

별도의 삭제 함수가 없는 것은 도메인에서 혹시라도 세션을 생성하고 삭제하는 것을 깜빡하고 잊었을 때 session이 해제되지 않는 문제가 생길 수 있기 때문입니다.

Resolve #7 