### PR TITLE
Fix/backup

### DIFF
--- a/infrastructure/mongo/mongodump.go
+++ b/infrastructure/mongo/mongodump.go
@@ -54,12 +54,12 @@ func ExecMongodump(options []string) error {
 	defer close(finishedChan)
 
 	if err = dump.Init(); err != nil {
-		//log.Logvf(log.Always, "Failed: %v", err)
+		log.Logvf(log.Always, "Failed: %v", err)
 		return err
 	}
 
 	if err = dump.Dump(); err != nil {
-		//log.Logvf(log.Always, "Failed: %v", err)
+		log.Logvf(log.Always, "Failed: %v", err)
 		return err
 	}
 

--- a/internal/adaptor/command/methods.go
+++ b/internal/adaptor/command/methods.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/Goboolean/manager-cli/internal/domain/entity"
 )
@@ -25,26 +24,6 @@ func (a *CommandAdaptor) BackupProduct(id string) error {
 
 func (a *CommandAdaptor) BackupProductToRemote(id string) error {
 	return a.backUpService.BackupProductToRemote(id)
-}
-
-func (a *CommandAdaptor) BackupAllBefore(date string) error {
-	t, err := time.Parse("2006/01/02", date)
-
-	if err != nil {
-		return err
-	}
-
-	return a.backUpService.BackupDataBefore(t)
-}
-
-func (a *CommandAdaptor) BackupAllToRemoteBefore(date string) error {
-	t, err := time.Parse("2006/01/02", date)
-
-	if err != nil {
-		return err
-	}
-
-	return a.backUpService.BackupDataToRemoteBefore(t)
 }
 
 type RegisterParms struct {

--- a/internal/adaptor/trade-repo-dump/constructor.go
+++ b/internal/adaptor/trade-repo-dump/constructor.go
@@ -8,8 +8,6 @@ type TradeDumpAdaptor struct {
 	Host     string
 	Port     string
 	Database string
-
-	baseOutDir string
 }
 
 func New(c *resolver.ConfigMap, outDir string) *TradeDumpAdaptor {
@@ -45,7 +43,5 @@ func New(c *resolver.ConfigMap, outDir string) *TradeDumpAdaptor {
 		Host:     host,
 		Port:     port,
 		Database: database,
-
-		baseOutDir: outDir,
 	}
 }

--- a/internal/domain/service/backup/constuctor.go
+++ b/internal/domain/service/backup/constuctor.go
@@ -2,17 +2,37 @@ package backup
 
 import "github.com/Goboolean/manager-cli/internal/port/out"
 
+// format date to yyyy-mm-dd_hh:mm:ss
+const toolTimeFormatString = "2006-01-02_15:04:05"
+
+const backupTypeFull = "f"
+const backupTypeDifferential = "d"
+const backupTypeSpecific = "s"
+
 type BackupService struct {
-	tradeRepo   out.TradeRepositoryPort
-	transmit    out.DataTransmitterPort
-	fileRemover out.FilePort
+	txCreator    out.TransactionCreator
+	tradeDumper  out.TradeDumperPort
+	metadataRepo out.MetadataRepositoryPort
+	transmitter  out.DataTransmitterPort
+	fileRemover  out.FilePort
+	backUpDir    string
 }
 
 // TODO: Find good name for field and parm
-func New(tradeRepoPort out.TradeRepositoryPort, transmitter out.DataTransmitterPort, fileRemover out.FilePort) *BackupService {
+func New(
+	transactionCreator out.TransactionCreator,
+	tradeRepoPort out.TradeDumperPort,
+	metadataRepoPort out.MetadataRepositoryPort,
+	transmitter out.DataTransmitterPort,
+	fileRemover out.FilePort,
+	outDir string) *BackupService {
+
 	return &BackupService{
-		tradeRepo:   tradeRepoPort,
-		transmit:    transmitter,
-		fileRemover: fileRemover,
+		txCreator:    transactionCreator,
+		tradeDumper:  tradeRepoPort,
+		metadataRepo: metadataRepoPort,
+		transmitter:  transmitter,
+		fileRemover:  fileRemover,
+		backUpDir:    outDir,
 	}
 }

--- a/internal/port/out/data-transmitter.go
+++ b/internal/port/out/data-transmitter.go
@@ -4,5 +4,5 @@ import "github.com/Goboolean/manager-cli/internal/domain/entity"
 
 type DataTransmitterPort interface {
 	//This method transmit data to remote storage
-	TransmitDataToRemote(file entity.FileManager) error
+	TransmitDataToRemote(file []entity.FileManager) error
 }

--- a/internal/port/out/file.go
+++ b/internal/port/out/file.go
@@ -2,6 +2,7 @@ package out
 
 import "github.com/Goboolean/manager-cli/internal/domain/entity"
 
+// Defines Port for file operation ex: create, remove, copy, move
 type FilePort interface {
 	RemoveFile(target entity.FileManager) error
 }

--- a/internal/port/out/persistences.go
+++ b/internal/port/out/persistences.go
@@ -25,15 +25,10 @@ type StatusPort interface {
 	SetStatus(id string, status entity.ProductStatus) error
 }
 
-type TradeRepositoryPort interface {
-	TransactorPort
+type TradeDumperPort interface {
 
-	// This method dumps trade data from trade data repository
-	DumpTradeRepo() (entity.FileManager, error)
-	// This method dumps trade data created before a specific date
-	DumpTradeRepoBefore(date time.Time) (entity.FileManager, error)
-	// This method dumps trade data of specific product
-	DumpProduct(id string) (entity.FileManager, error)
 	// This method dumps trade data of specific product created before time
-	DumpProductBefore(id string, time time.Time) (entity.FileManager, error)
+	DumpProductBefore(id string, outDir string, time time.Time) ([]entity.FileManager, error)
+	// This method dumps trade data of specific product created between time
+	DumpProductBetween(id string, outDir string, from, to time.Time) ([]entity.FileManager, error)
 }


### PR DESCRIPTION
백업 관련된 부분 손을 봤습니다.
1. 포트
- 포트에는 가장 작은 단위의 작업만 남기고 지웠습니다.
- 증분백업에 대비해 특정 시점 사이의 데이터를 백업하는 인터페이스를 수정했습니다.
2. 어댑터
- 압축 파일로 export하게 수정했습니다.
- 모든 메서드가 특정한 종목만을 다루므로 백업 파일이 있는 디렉토리에 대한 정보를 반환하는 것이 아니라 dump된 파일의 정보를 직접 반환하도록 수정했습니다.